### PR TITLE
Add option 'g:niceblock_no_default_key_mappings'

### DIFF
--- a/doc/niceblock.txt
+++ b/doc/niceblock.txt
@@ -29,6 +29,7 @@ CONTENTS					*niceblock-contents*
 Introduction            |niceblock-introduction|
 Interface               |niceblock-interface|
   Key Mappings            |niceblock-key-mappings|
+Customization           |niceblock-customization|
 Bugs                    |niceblock-bugs|
 Changelog               |niceblock-changelog|
 
@@ -118,6 +119,15 @@ NAMED KEY MAPPINGS				*niceblock-named-key-mappings*
 <Plug>(niceblock-A)				*<Plug>(niceblock-A)*
 			Like |<Plug>(niceblock-I)|, but it's corresponding to
 			|v_b_A| instead of |v_b_I|.
+
+==============================================================================
+CUSTOMIZATION 					*niceblock-customiztion*
+
+------------------------------------------------------------------------------
+                                           *g:niceblock_no_default_key_mappings*
+Values: 0 or 1.
+Default: 0
+Use |g:niceblock_no_default_key_mappings| to disable default mappings.
 
 
 

--- a/plugin/niceblock.vim
+++ b/plugin/niceblock.vim
@@ -33,9 +33,12 @@ vnoremap <expr> <Plug>(niceblock-I)  niceblock#force_blockwise('I')
 vnoremap <expr> <Plug>(niceblock-gI)  niceblock#force_blockwise('gI')
 vnoremap <expr> <Plug>(niceblock-A)  niceblock#force_blockwise('A')
 
-silent! xmap <unique> I  <Plug>(niceblock-I)
-silent! xmap <unique> gI  <Plug>(niceblock-gI)
-silent! xmap <unique> A  <Plug>(niceblock-A)
+if !exists('g:niceblock_no_default_key_mappings') ||
+			\  !g:niceblock_no_default_key_mappings
+	silent! xmap <unique> I  <Plug>(niceblock-I)
+	silent! xmap <unique> gI  <Plug>(niceblock-gI)
+	silent! xmap <unique> A  <Plug>(niceblock-A)
+endif
 
 
 


### PR DESCRIPTION
I noticed that the plugin conflicts with [tagets](https://github.com/wellle/targets.vim)(mappings). And just add option that disable default mappings(g:niceblock_no_default_key_mappings).